### PR TITLE
Update README for performing mongoimport with JSON array

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The Jeopardy! dataset (216,930 Jeopardy! questions in JSON format) is available 
 ### Create Your API
 
 ##### Start Mongo
-Start Mongo locally and load your data into your local MongoDB. (Your process will vary, but you could use something like `mongoimport  --db test --collection jeopardy --file JEOPARDY_QUESTIONS.txt`
+Start Mongo locally and load your data into your local MongoDB. (Your process will vary, but you could use something like `mongoimport  --db test --collection jeopardy --file JEOPARDY_QUESTIONS1.json --jsonArray`.
 
 ##### Time for LoopBack! 
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The Jeopardy! dataset (216,930 Jeopardy! questions in JSON format) is available 
 ### Create Your API
 
 ##### Start Mongo
-Start Mongo locally and load your data into your local MongoDB. (Your process will vary, but you could use something like `mongoimport  --db test --collection jeopardy --file JEOPARDY_QUESTIONS1.json --jsonArray`.
+Start Mongo locally and load your data into your local MongoDB. (Your process will vary, but you could use something like `mongoimport  --db test --collection jeopardyQuestion --file JEOPARDY_QUESTIONS1.json --jsonArray`.
 
 ##### Time for LoopBack! 
 


### PR DESCRIPTION
Following the README instructions, the `mongoimport` command failed for me. I updated the command based on the [file downloaded from the link](https://drive.google.com/file/d/0BwT5wj_P7BKXb2hfM3d2RHU1ckE/view). The main change is that the file is a JSON array, so the command requires `--jsonArray` to be passed in.